### PR TITLE
Add Title bar

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+################################################################################
+################################################################################
+#
+# Module: ci.py
+#
+# Notes:
+#
+# Small script to automate running unit tests on each PR.
+#
+################################################################################
+################################################################################
+
+import helpers
+import os
+import shutil
+import unittest
+import xmlrunner
+
+from collections import defaultdict
+
+################################################################################
+# Unit Tests
+################################################################################
+
+class RestTests(unittest.TestCase):
+   def test_setup(self):
+      # Simple test to make sure the unit tester is working correctly.
+      pass
+
+   # index.py takes a dependency on the function helpers.get_title_menu_options
+   # returning a list of strings when called.
+   def test_get_title_menu_options(self):
+      menu_options_first_call = helpers.get_title_menu_options()
+
+      for menu_option in menu_options_first_call:
+         if not isinstance(menu_option, str):
+            error_str = "Error, menu option must be a string."
+            self.fail("%s Type: %s" % (error_str, type(menu_option)))
+
+      # Sanity check, make sure repeated calls returns the same values
+      menu_options_second_call = helpers.get_title_menu_options()
+
+      if len(menu_options_first_call) !=  len(menu_options_second_call):
+         error_str = "Error, repeated calls to get_title_menu_options yielded"
+         error_str += " different results."
+         first = menu_options_first_call
+         second = menu_options_second_call
+
+         self.fail("%s: %s, %s" % (error_str, first, second))
+
+      for index, menu_option in enumerate(menu_options_second_call):
+         if not isinstance(menu_option, str):
+            error_str = "Error, menu option must be a string."
+            self.fail("%s Type: %s" % (error_str, type(menu_option)))
+
+         if menu_option != menu_options_first_call[index]:
+            error_str = "Error, repeated calls to get_title_menu_options yielded"
+            error_str += " different results."
+            first = menu_options_first_call
+            second = menu_options_second_call
+
+            self.fail("%s: %s, %s" % (error_str, first, second))
+
+################################################################################
+# Main
+################################################################################
+
+if __name__ == "__main__":
+   # Remove previous xml files.
+   shutil.rmtree("test-reports")
+
+   unittest.main(testRunner=xmlrunner.XMLTestRunner(output='test-reports'))

--- a/helpers.py
+++ b/helpers.py
@@ -2,32 +2,32 @@
 ################################################################################
 ################################################################################
 #
-# Module: ci.py
+# Module: helpers.py
 #
-# Notes:
+# Notes
 #
-# Small script to automate running unit tests on each PR.
+# A bunch of helper functions for the use of index.py
 #
 ################################################################################
 ################################################################################
-
-import os
-import unittest
 
 from collections import defaultdict
 
 ################################################################################
-# Unit Tests
+# Globals
 ################################################################################
 
-class RestTests(unittest.TestCase):
-   def test_setup(self):
-      # Simple test to make sure the unit tester is working correctly.
-      pass
+title_menu_options_file = "title_menu_options.txt"
 
 ################################################################################
-# Main
 ################################################################################
 
-if __name__ == "__main__":
-   unittest.main()
+def get_title_menu_options():
+   title_options = []
+
+   with open(title_menu_options_file) as file_handle:
+      for line in file_handle:
+         # Make sure the options do not have any new lines, or spaces.
+         title_options.append(line.strip())
+
+   return title_options

--- a/index.py
+++ b/index.py
@@ -2,11 +2,7 @@
 ################################################################################
 ################################################################################
 #
-# Module: ci.py
-#
-# Notes:
-#
-# Small script to automate running unit tests on each PR.
+# Module: index.py
 #
 ################################################################################
 ################################################################################
@@ -15,6 +11,8 @@ import os
 
 import tornado.ioloop
 import tornado.web
+
+import helpers
 
 from collections import defaultdict
 
@@ -26,17 +24,14 @@ template_path = os.path.join(os.path.dirname(__file__), "templates")
 static_path = template_path = os.path.join(os.path.dirname(__file__), "static")
 
 ################################################################################
-# Helper Functions
-################################################################################
-
-################################################################################
 # Handlers
 ################################################################################
 
 class MainHandler(tornado.web.RequestHandler):
    def get(self):
       self.render(
-         os.path.join("templates", "index.html")
+         os.path.join("templates", "index.html"),
+         title_menu_options=helpers.get_title_menu_options()
       )
 
 def make_app():

--- a/static/index.css
+++ b/static/index.css
@@ -1,0 +1,53 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*  Module: index.css                                                         */
+/*                                                                            */
+/*  Notes:                                                                    */
+/*                                                                            */
+/*  Default styling for the main page                                         */
+/*                                                                            */
+/* ************************************************************************** */
+
+/* ************************************************************************** */
+/* =.g_menu_bar                                                               */
+/*                                                                            */
+/* Notes: styling for the menu bar                                            */
+/* ************************************************************************** */
+
+.g_menu_bar
+{
+   width: 100%;
+   height: 3em;
+   background-color: #F2EDED;
+   display: table;
+}
+
+/* ************************************************************************** */
+/* =.g_menu_bar > span                                                        */
+/*                                                                            */
+/* Notes: styling for the menu bar items                                      */
+/* ************************************************************************** */
+
+.g_menu_bar > span
+{
+   height: 100%;
+   font-family: wf_segoe-ui_normal,HelveticaNeue-Light,Helvetica Neue Light,Helvetica Neue,Helvetica,Arial,sans-serif;
+   color: #4d3a2f;
+   width: 3em;
+   text-align: center;
+   display: table-cell;
+   vertical-align: middle;
+   cursor: default;
+}
+
+/* ************************************************************************** */
+/* =.g_right_div                                                              */
+/* ************************************************************************** */
+
+.g_right_div
+{
+   min-height: 100%;
+   width: 70%;
+   margin-left: auto;
+   margin-right: auto;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,9 +10,19 @@
 <html>
    <head>
       <link href="{{ static_url('global.css') }}" rel="stylesheet" type="text/css">
+      <link href="{{ static_url('index.css') }}" rel="stylesheet" type="text/css">
    </head>
-   
    <body>
+      <!-- -------------------------------------------------------------- -->
+      <!-- Body                                                           -->
+      <!-- -------------------------------------------------------------- -->
+      <div class="g_right_div">
+         <div class="g_menu_bar">
+            {% for title_menu_option in title_menu_options %}
+            <span>{{title_menu_option}}</span>
+            {% end %}
+         </div>
+      </div>
   
    </body>
 

--- a/title_menu_options.txt
+++ b/title_menu_options.txt
@@ -1,0 +1,5 @@
+Inicio
+Equipo
+Tratamientos
+Nuestros Centros
+Cita Online


### PR DESCRIPTION
Add the title bar, this adds all of the styling necessary to start the the title bar later. It is not the final location of the bar; however, the sizing should be correct.

Additionally ci.py is moved to the top of the repo and a unit test is added for get_title_menu_options.

Fixes #7 
